### PR TITLE
Fix xlsx import

### DIFF
--- a/pages/invoices.vue
+++ b/pages/invoices.vue
@@ -135,7 +135,6 @@
 </template>
 
 <script setup>
-import * as XLSX from 'xlsx'
 import dayjs from 'dayjs'
 const { RestApi } = useApi()
 const userStore = useUserStore()
@@ -382,7 +381,9 @@ const printInvoice = async (invoice) => {
   `)
   doc.close()
 }
-const exportToExcel = () => {
+const exportToExcel = async () => {
+  const mod = await import('xlsx')
+  const XLSX = mod.default || mod
 
   const rows = []
   invoices.value.forEach((inv, i) => {

--- a/pages/test.vue
+++ b/pages/test.vue
@@ -177,7 +177,6 @@
 </template>
 
 <script setup>
-import * as XLSX from 'xlsx'
 import dayjs from 'dayjs'
 const { RestApi } = useApi()
 
@@ -391,9 +390,12 @@ const html = `
   doc.write(html)
   doc.close()
 }
-const exportToExcel = () => {
+const exportToExcel = async () => {
+  const mod = await import('xlsx')
+  const XLSX = mod.default || mod
   
-const rows = []
+
+  const rows = []
   invoices.value.forEach((inv, i) => {
     rows.push({
       'STT': i + 1,


### PR DESCRIPTION
## Summary
- dynamically load `xlsx` only on the client so SSR doesn't fail

## Testing
- `yarn build` *(fails: Request was cancelled due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_b_684cdaa0e9648331b60a8b31ef8644ec