### PR TITLE
Set invoice page default date to today

### DIFF
--- a/pages/invoices.vue
+++ b/pages/invoices.vue
@@ -141,8 +141,8 @@ const userStore = useUserStore()
 const param = ref({
   // page: 1,
   // limit: 10,
-  from: dayjs().startOf('month').format('DD/MM/YYYY'),
-  to: dayjs().endOf('month').format('DD/MM/YYYY'),
+  from: dayjs().format('DD/MM/YYYY'),
+  to: dayjs().format('DD/MM/YYYY'),
   code: ''
 })
 const dateRange = ref([


### PR DESCRIPTION
## Summary
- default the invoice filter's date range to the current day

## Testing
- `yarn install`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_68554d63d5088331be8d293549a3c790